### PR TITLE
Change a symbol into a string for regexp-opt.

### DIFF
--- a/nsis-mode.el
+++ b/nsis-mode.el
@@ -339,7 +339,7 @@
   "* nsis syntax function")
 (defvar nsis-syntax-directive
   '(
-    !include
+    "!include"
     "!addincludedir"
     "!addplugindir"
     "!appendfile"


### PR DESCRIPTION
There is a symbol in `nsis-syntax-directive`, which is passed to `regexp-opt`. However, `regexp-opt` only accepts strings.
