### PR TITLE
add deprecated commands

### DIFF
--- a/nsis-mode.el
+++ b/nsis-mode.el
@@ -147,7 +147,6 @@
     "CompletedText"
     "ComponentText"
     "DetailsButtonText"
-    "DirShow"
     "DirText"
     "DirVar"
     "DirVerify"
@@ -202,8 +201,6 @@
     "SilentUnInstall"
     "SpaceTexts"
     "SubCaption"
-    "SubSection"
-    "SubSectionEnd"
     "Unicode"
     "UninstPage"
     "UninstallButtonText"
@@ -754,6 +751,24 @@
     "KillTimer"
     )
   "NSD functions")
+(defvar nsis-syntax-deprecated
+  '(
+    "CompareDLLVersions"
+    "CompareFileTimes"
+    "DirShow"
+    "DisabledBitmap"
+    "EnabledBitmap"
+    "GetFullDLLPath"
+    "GetParent"
+    "GetWinampInstPath"
+    "PackEXEHeader"
+    "SectionDivider"
+    "SetPluginUnload"
+    "SubSection"
+    "SubSectionEnd"
+    "UninstallExeName"
+    )
+  "* nsis syntax deprecated")
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Font Lock Keywords
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
I've created a new group for deprecated command, moved some commands there and added the others. IMHO, they should be marked error, as the compiler will throw an error (no warning). I'm not sure how to assign `font-lock-error-face` to that group (maybe you can takeover?).