### PR TITLE
Combine multiple auto-mode-alist entries into one entry.

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,16 +24,20 @@ A major mode for editing nsis files
 
 * Installation
 
-Put this =nsis-mode= the load path, then add the following to your Emacs:
+If you're using =use-package= you can add this to your init file:
+#+BEGIN_SRC emacs-lisp
+ (use-package nsis-mode)
+#+END_SRC
+
+That's all!
+
+Else you can install =nsis-mode= from Melpa via =M-x package-install=, then
+add the following to your Emacs:
 #+BEGIN_SRC emacs-lisp
  (autoload 'nsis-mode "nsis-mode" "NSIS mode" t)
 
- (setq auto-mode-alist (append '(("\\.\\([Nn][Ss][Ii]\\)$" .
+ (setq auto-mode-alist (append '(("\\.[Nn][Ss][HhIi]\\'" .
                                   nsis-mode)) auto-mode-alist))
-
- (setq auto-mode-alist (append '(("\\.\\([Nn][Ss][Hh]\\)$" .
-                                  nsis-mode)) auto-mode-alist))
-
 #+END_SRC
 
 * History

--- a/Readme.md
+++ b/Readme.md
@@ -24,16 +24,20 @@ A major mode for editing nsis files
 
 ## Installation
 
-Put this `nsis-mode` the load path, then add the following to your Emacs:
+If you're using [use-package](https://jwiegley.github.io/use-package/) you can
+add this to your init file:
+
+ (use-package nsis-mode)
+
+That's all!
+
+Else you can install `nsis-mode` from Melpa via `M-x package-install`, then
+add the following to your Emacs:
 
  (autoload 'nsis-mode "nsis-mode" "NSIS mode" t)
 
- (setq auto-mode-alist (append '(("\\.\\([Nn][Ss][Ii]\\)$" .
+ (setq auto-mode-alist (append '(("\\.[Nn][Ss][HhIi]\\'" .
                                   nsis-mode)) auto-mode-alist))
-
- (setq auto-mode-alist (append '(("\\.\\([Nn][Ss][Hh]\\)$" .
-                                  nsis-mode)) auto-mode-alist))
-
 
 
 ## History

--- a/nsis-mode.el
+++ b/nsis-mode.el
@@ -25,14 +25,11 @@
 ;; 
 ;; * Installation
 ;; 
-;; Put this `nsis-mode' the load path, then add the following to your Emacs:
+;; Put nsis-mode on your load-path, then add the following to your Emacs:
 ;; 
 ;;  (autoload 'nsis-mode "nsis-mode" "NSIS mode" t)
 ;; 
-;;  (setq auto-mode-alist (append '(("\\.\\([Nn][Ss][Ii]\\)$" .
-;;                                   nsis-mode)) auto-mode-alist))
-;; 
-;;  (setq auto-mode-alist (append '(("\\.\\([Nn][Ss][Hh]\\)$" .
+;;  (setq auto-mode-alist (append '(("\\.[Nn][Ss][HhIi]\\'" .
 ;;                                   nsis-mode)) auto-mode-alist))
 ;; 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -119,11 +116,9 @@
 
 (defvar nsis-version "0.3"
   "NSIS-mode version")
+
 ;;;###autoload
-(setq auto-mode-alist (append '(("\\.\\([Nn][Ss][Ii]\\)$" .
-                                 nsis-mode)) auto-mode-alist))
-;;;###autoload
-(setq auto-mode-alist (append '(("\\.\\([Nn][Ss][Hh]\\)$" .
+(setq auto-mode-alist (append '(("\\.[Nn][Ss][HhIi]\\'" .
                                  nsis-mode)) auto-mode-alist))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/nsis-mode.texi
+++ b/nsis-mode.texi
@@ -56,13 +56,24 @@ A major mode for editing nsis files
 
 @node Installation
 @section Installation
-Put this @code{nsis-mode} the load path@comma{} then add the following to your Emacs:
+If you use @code{use-package} you can add this to your init file:
 
+@example
+(use-package nsis-mode)
+@end example
+
+That's all!
+
+Else, you can install @code{nsis-mode} from Melpa via
+@code{M-x package-install}, then add the following to your Emacs:
+
+@example
+@group
 (autoload 'nsis-mode "nsis-mode" "NSIS mode" t)
 
-(setq auto-mode-alist (append '(("\.\([Nn][Ss][Ii]\)$" . nsis-mode)) auto-mode-alist))
-
-(setq auto-mode-alist (append '(("\.\([Nn][Ss][Hh]\)$" . nsis-mode)) auto-mode-alist))
+(setq auto-mode-alist (append '(("\\.[Nn][Ss][HhIi]\\'" . nsis-mode)) auto-mode-alist))
+@end group
+@end example
 
 @node History
 @section History


### PR DESCRIPTION
We can combine the auto-mode-alist entries for nsis-mode into a single
entry by extending the class entry for the final letter, and simplify
the matching regex by using \' instead of $ and removing the grouping.

Update all the various documentation files to suggest using use-package
or, at least, installing via the Emacs package manager instead of by
hand.