### PR TITLE
Fix eval-when-compile defvar forms for byte/native compilation

### DIFF
--- a/nsis-mode.el
+++ b/nsis-mode.el
@@ -191,7 +191,7 @@
 ;; Keywords from HM NIS Edit source Syntax.ini and the manuals.  Added logic lib
 ;; and other libraries.
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-syntax-reserved-word
     '(
       "AddBrandingImage"
@@ -1976,7 +1976,7 @@ Run run the NSI output then."
 ;; Indention function
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-end-keywords
         (replace-regexp-in-string "@" "\\<!insertmacro[ \t]+.*?END[ \t]*$"
                                   (replace-regexp-in-string "'" "\\>"
@@ -1998,7 +1998,7 @@ Run run the NSI output then."
   ;;"* Regular expression of nsis ending keywords"
   )
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-start-keywords
         (replace-regexp-in-string "@" "\\<!insertmacro[ \t]+.*?BEGIN[ \t]*$"
                                   (replace-regexp-in-string "'" "\\>"

--- a/nsis-mode.el
+++ b/nsis-mode.el
@@ -286,7 +286,7 @@
     )
   )
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-syntax-function
     '(
       "Abort"
@@ -425,7 +425,7 @@
     "* nsis syntax function")
   )
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-syntax-directive
     '(
       "!addincludedir"
@@ -467,7 +467,7 @@
     "NSIS syntax directive")
   )
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-syntax-parameter
     '(
       "custom"
@@ -574,7 +574,7 @@
     )
   )
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-syntax-parameter-slash
     '(
       "/BOM"
@@ -637,7 +637,7 @@
     "* nsis Parameters (w/slash)")
   )
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-syntax-variable
     (append
      ;; Unlike what is in HM NIS editor, there are 20 registers, put
@@ -710,7 +710,7 @@
     )
   )
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-syntax-callback
     '(
       ".onGUIEnd"
@@ -867,7 +867,7 @@
     )
   "NSD Macros.")
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-syntax-nsd
     '(
       "Create"
@@ -888,7 +888,7 @@
     "NSD functions")
   )
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-syntax-deprecated
     '(
       "CompareDLLVersions"
@@ -1203,7 +1203,7 @@
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Imenu
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-imenu-generic-expression
     (reverse
      (list
@@ -2024,7 +2024,7 @@ Run run the NSI output then."
   ;;"* Regular expression of nsis beginning keywords"
   )
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-indent-deindent-keywords
     (replace-regexp-in-string "@" "^[ \t]*[^-+!$0-9\n \t;#\"][^ \t\n]*?:[ \t]*\\($\\|[#;]\\|/[*].*?[*]/[ \t]*$\\|/[*].*?$\\)\\|^[ \t]*\"[^-+!$0-9\n \t;#][^ \t\n]*?:\"[ \t]*\\($\\|[#;]\\|/[*].*?[*]/[ \t]*$\\|/[*].*?$\\)"
                               (regexp-opt
@@ -2039,7 +2039,7 @@ Run run the NSI output then."
                                         ;"Regular expression of indent-deindent keywords statements for indent-deindent-keywords "
   )
 
-(eval-when-compile
+(eval-and-compile
   (defvar nsis-indent-orphans
     (replace-regexp-in-string "@" "^[ \t]*[^-+!$0-9\n \t;#\"][^ \t\n]*?:[ \t]*\\($\\|[#;]\\|/[*].*?[*]/[ \t]*$\\|/[*].*?$\\)\\|^[ \t]*\"[^-+!$0-9\n \t;#][^ \t\n]*?:\"[ \t]*\\($\\|[#;]\\|/[*].*?[*]/[ \t]*$\\|/[*].*?$\\)"
                               (regexp-opt


### PR DESCRIPTION
## Summary

All `defvar` forms for syntax definition variables (`nsis-syntax-function`,
`nsis-syntax-directive`, `nsis-syntax-variable`, `nsis-syntax-callback`, etc.)
were wrapped in `eval-when-compile`, making them available only at compile
time. This caused two classes of errors:

1. **Runtime void-variable errors** (fixes #16): When loading the
   byte-compiled `.elc` file, `nsis-syntax-reserved-word`,
   `nsis-end-keywords`, and `nsis-start-keywords` were void at runtime,
   breaking `nsis-forward-fold` and `nsis-hs-start`.

2. **Native compilation eager macro-expansion failure**: During Emacs native
   compilation, eager macro expansion tried to reference variables like
   `nsis-syntax-variable` and `nsis-syntax-directive` before they were
   defined, producing: `Eager macro-expansion failure: (wrong-type-argument
   sequencep !include)`

The fix changes all `eval-when-compile` wrappers around `defvar` forms to
`eval-and-compile`, which evaluates at both compile time and load time.
The `eval-when-compile` consumer sites in `nsis-font-lock-keywords` and
indentation code are left unchanged -- they correctly reference these
now-guaranteed-to-be-defined variables.

## Changes

14 single-word changes (`eval-when-compile` -> `eval-and-compile`) across
two commits:

- `nsis-syntax-reserved-word` (line 194, was already `eval-and-compile`)
- `nsis-syntax-function` (line 289)
- `nsis-syntax-directive` (line 428)
- `nsis-syntax-parameter` (line 470)
- `nsis-syntax-parameter-slash` (line 577)
- `nsis-syntax-variable` (line 640)
- `nsis-syntax-callback` (line 713)
- `nsis-syntax-nsd` (line 870)
- `nsis-syntax-deprecated` (line 891)
- `nsis-imenu-generic-expression` (line 1206)
- `nsis-end-keywords` (line 1979, was already `eval-and-compile`)
- `nsis-start-keywords` (line 2001, was already `eval-and-compile`)
- `nsis-indent-deindent-keywords` (line 2027)
- `nsis-indent-orphans` (line 2042)

## Test plan

- [x] Loads cleanly from source: `emacs --batch -L . -l nsis-mode`
- [x] Byte-compiles without errors: `emacs -Q --batch -f batch-byte-compile nsis-mode.el`
- [x] Native-compiles without errors: `emacs -Q --batch --eval '(native-compile "nsis-mode.el")'`
- [x] All syntax/indentation variables are bound at runtime after `.elc` load